### PR TITLE
update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,10 @@ To reformat code to match the existing style, run `black` on any changed sources
 
 ### VISR
 
-Get VISR 0.13.0 or greater. Currently this is available here:
+Get VISR 0.13.0 or greater. Currently this is available in the `visr` branch of this repository, or here:
 
-https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip
+- zip: https://github.com/ebu/bear/archive/refs/heads/visr.zip
+- tar.gz: https://github.com/ebu/bear/archive/refs/heads/visr.tar.gz
 
 Eventually this will be available from the upstream repository:
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "ear_src": {
       "flake": false,
       "locked": {
-        "lastModified": 1670415759,
-        "narHash": "sha256-wkzfmqqnY5Nzw3Rr5kpnpIZ5kuQygUxHidMN9QZEI/Q=",
+        "lastModified": 1696330591,
+        "narHash": "sha256-dpJtZ974HrSklPIh78UByjhEGsbVyltklceIcCZ81a4=",
         "ref": "master",
-        "rev": "ef2189021203101eab323e1eccdd2527b32a5024",
-        "revCount": 220,
+        "rev": "29efa875c772e86b09c9154381cbe2d1db60f999",
+        "revCount": 239,
         "type": "git",
         "url": "https://github.com/ebu/ebu_adm_renderer.git"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -18,12 +18,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -70,6 +73,21 @@
         "flake-utils": "flake-utils",
         "libear_src": "libear_src",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -94,14 +94,18 @@
     "visr_src": {
       "flake": false,
       "locked": {
-        "lastModified": 1643817083,
-        "narHash": "sha256-B+x/wRJgHyWxw3TlMabEK9C6vbH2mr8NwAvPAqn8+ck=",
-        "type": "tarball",
-        "url": "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip"
+        "lastModified": 1700565411,
+        "narHash": "sha256-b/q38V6H2xTRQNMU1a7u5CKUWkWlRR23doJ1lrh1dPI=",
+        "ref": "visr",
+        "rev": "4bba6abfbfab69c0ac0c1dd045733ce597df36f6",
+        "revCount": 11,
+        "type": "git",
+        "url": "https://github.com/ebu/bear.git"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip"
+        "ref": "visr",
+        "type": "git",
+        "url": "https://github.com/ebu/bear.git"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -51,16 +51,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677779205,
-        "narHash": "sha256-6DBjL9wjq86p2GczmwnHtFRnWPBPItc67gapWENBgX8=",
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96e18717904dfedcd884541e5a92bf9ff632cf39",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -72,7 +72,8 @@
         "ear_src": "ear_src",
         "flake-utils": "flake-utils",
         "libear_src": "libear_src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "visr_src": "visr_src"
       }
     },
     "systems": {
@@ -88,6 +89,19 @@
         "owner": "nix-systems",
         "repo": "default",
         "type": "github"
+      }
+    },
+    "visr_src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1643817083,
+        "narHash": "sha256-B+x/wRJgHyWxw3TlMabEK9C6vbH2mr8NwAvPAqn8+ck=",
+        "type": "tarball",
+        "url": "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,9 @@
   };
 
   inputs.visr_src = {
-    url = "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip";
+    type = "git";
+    url = "https://github.com/ebu/bear.git";
+    ref = "visr";
     flake = false;
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,12 @@
     flake = false;
   };
 
-  outputs = { self, nixpkgs, flake-utils, ear_src, libear_src }:
+  inputs.visr_src = {
+    url = "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip";
+    flake = false;
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ear_src, libear_src, visr_src }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -60,7 +65,7 @@
             ear = pkgs.callPackage ./nix/ear.nix { inherit python; src = ear_src; };
             libear = pkgs.callPackage ./nix/libear.nix { inherit xsimd; src = libear_src; };
 
-            visr = pkgs.callPackage ./nix/visr.nix { inherit python; };
+            visr = pkgs.callPackage ./nix/visr.nix { inherit python; src = visr_src; };
             visr_python = python.pkgs.toPythonModule visr;
 
             visr_bear = pkgs.callPackage ./nix/visr_bear.nix { inherit python data_files libear visr_python; src = visr_bear_src; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "nixpkgs/nixos-22.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-23.05";
 
   inputs.ear_src = {
     type = "git";

--- a/nix/bear.nix
+++ b/nix/bear.nix
@@ -1,4 +1,4 @@
-{ lib, src, python, ear, visr_python ? null, numpy_quaternion, snakemake, visr_bear ? null }:
+{ lib, src, python, ear, visr_python ? null, numpy_quaternion, visr_bear ? null }:
 python.pkgs.buildPythonPackage rec {
   name = "bear";
   inherit src;

--- a/nix/bear.nix
+++ b/nix/bear.nix
@@ -3,7 +3,7 @@ python.pkgs.buildPythonPackage rec {
   name = "bear";
   inherit src;
   propagatedBuildInputs = with python.pkgs; [ numpy ear setuptools visr_python visr_bear ];
-  checkInputs = [ python.pkgs.pytest numpy_quaternion ];
+  nativeCheckInputs = [ python.pkgs.pytest numpy_quaternion ];
   checkPhase = lib.optionalString (visr_bear != null) ''
     pytest visr_bear/test
   '';

--- a/nix/ear.nix
+++ b/nix/ear.nix
@@ -2,10 +2,6 @@
 python.pkgs.buildPythonPackage rec {
   name = "ear";
   inherit src;
-  propagatedBuildInputs = with python.pkgs; [ numpy scipy six attrs multipledispatch lxml ruamel_yaml setuptools ];
+  propagatedBuildInputs = with python.pkgs; [ numpy scipy six attrs multipledispatch lxml pyyaml setuptools ];
   doCheck = false;
-  postPatch = ''
-    # latest attrs should be fine...
-    sed -i "s/'attrs.*'/'attrs'/" setup.py
-  '';
 }

--- a/nix/visr.nix
+++ b/nix/visr.nix
@@ -1,10 +1,7 @@
-{ stdenv, cmake, python, boost, fetchzip }:
+{ stdenv, cmake, python, boost, fetchzip, src }:
 stdenv.mkDerivation rec {
   name = "VISR";
-  src = fetchzip {
-    url = "https://github.com/ebu/bear/releases/download/v0.0.1-pre/visr-0.13.0-pre-5e13f020.zip";
-    sha256 = "1jgrzjlh5kqbq06vz6pnn6yvml1bqjk33rblqfqja7v02b0pzv07";
-  };
+  inherit src;
   nativeBuildInputs = [ cmake boost python.buildEnv ];
   cmakeFlags = [
     "-DBUILD_AUDIOINTERFACES_PORTAUDIO=FALSE"

--- a/nix/visr.nix
+++ b/nix/visr.nix
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     "-DBUILD_STANDALONE_APPLICATIONS=false"
   ];
   postPatch = ''
-    sed -i "s%set( PYTHON_MODULE_INSTALL_DIRECTORY .*$%set( PYTHON_MODULE_INSTALL_DIRECTORY \"$out/${python.sitePackages}\")%" CMakeLists.txt
-    sed -i 's/ADD_SUBDIRECTORY( apps )//' src/CMakeLists.txt
+    substituteInPlace CMakeLists.txt \
+      --replace "\''${VISR_TOPLEVEL_INSTALL_DIRECTORY}/python" "$out/${python.sitePackages}"
   '';
 }


### PR DESCRIPTION
To make updating it a bit easier, VISR is now pushed to a branch of this repository, `visr`.

This isn't completely ideal -- it should be a submodule or subtree, but I don't want to deal with integration yet, or bloating the clone size by >100M.

The version tested against is listed in `flake.lock`, at `nodes.visr_src.locked.rev`.